### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.md


### PR DESCRIPTION
Include missing files in sdist for #1

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.6KII7Mduop
+ trap 'rm -rf /tmp/tmp.6KII7Mduop' EXIT
+ python -m venv /tmp/tmp.6KII7Mduop
+ python setup.py sdist -d /tmp/tmp.6KII7Mduop
running sdist
running egg_info
writing lib_attacher.egg-info/PKG-INFO
writing dependency_links to lib_attacher.egg-info/dependency_links.txt
writing top-level names to lib_attacher.egg-info/top_level.txt
reading manifest file 'lib_attacher.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'lib_attacher.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md

running check
creating lib_attacher-0.0.1
creating lib_attacher-0.0.1/lib_attacher
creating lib_attacher-0.0.1/lib_attacher.egg-info
copying files to lib_attacher-0.0.1...
copying MANIFEST.in -> lib_attacher-0.0.1
copying readme.md -> lib_attacher-0.0.1
copying setup.py -> lib_attacher-0.0.1
copying lib_attacher/__init__.py -> lib_attacher-0.0.1/lib_attacher
copying lib_attacher.egg-info/PKG-INFO -> lib_attacher-0.0.1/lib_attacher.egg-info
copying lib_attacher.egg-info/SOURCES.txt -> lib_attacher-0.0.1/lib_attacher.egg-info
copying lib_attacher.egg-info/dependency_links.txt -> lib_attacher-0.0.1/lib_attacher.egg-info
copying lib_attacher.egg-info/top_level.txt -> lib_attacher-0.0.1/lib_attacher.egg-info
Writing lib_attacher-0.0.1/setup.cfg
Creating tar archive
removing 'lib_attacher-0.0.1' (and everything under it)
+ cd /
+ /tmp/tmp.6KII7Mduop/bin/pip install /tmp/tmp.6KII7Mduop/lib_attacher-0.0.1.tar.gz
Processing /tmp/tmp.6KII7Mduop/lib_attacher-0.0.1.tar.gz
Installing collected packages: lib-attacher
  Running setup.py install for lib-attacher: started
    Running setup.py install for lib-attacher: finished with status 'done'
Successfully installed lib-attacher-0.0.1
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.6KII7Mduop
```
